### PR TITLE
chore: add GitHub issue forms templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,45 @@
+name: "Bug"
+description: "Reporte de bug"
+title: "BUG: "
+labels: ["type:bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Resumen"
+      placeholder: "Qué pasa y qué debería pasar"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: "Pasos para reproducir"
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Resultado esperado"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Resultado actual"
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: "Entorno"
+      placeholder: "OS / navegador / versión / commit"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -1,0 +1,36 @@
+name: "Tech Debt / Refactor"
+description: "Deuda técnica, refactor o mejoras internas"
+title: "TECH: "
+labels: ["type:tech-debt"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: "Problema"
+      placeholder: "Qué está mal hoy (dolor técnico)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: "Propuesta"
+      placeholder: "Qué cambio harías y por qué"
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: "Riesgos / Impacto"
+      placeholder: "Impacto en módulos, regresiones posibles, etc."
+    validations:
+      required: false
+
+  - type: textarea
+    id: done
+    attributes:
+      label: "Criterio de completitud"
+      placeholder: "- Refactor aplicado\n- Tests actualizados\n- Sin cambios funcionales"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -1,0 +1,57 @@
+name: "User Story (HU)"
+description: "Historia de usuario para Stocky-App"
+title: "HU-XXX: "
+labels: ["type:feature", "needs-refinement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Instrucciones**
+        - Completa historia + criterios de aceptación.
+        - Agrega labels `area:*` y `priority:*`.
+        - Asigna Milestone (release) si entra a `MVP v1`.
+        - Story Points e Iteration se asignan en el **GitHub Project**.
+
+  - type: textarea
+    id: story
+    attributes:
+      label: "Historia (Como / Quiero / Para)"
+      placeholder: |
+        Como [tipo de usuario]
+        Quiero [acción]
+        Para [beneficio]
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: "Criterios de aceptación"
+      description: "Incluye happy path y al menos 1 caso inválido/error"
+      placeholder: |
+        1. Dado ..., cuando ..., entonces ...
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: business_rules
+    attributes:
+      label: "Reglas de negocio / Notas"
+      placeholder: |
+        - Validaciones:
+        - Restricciones:
+        - Consideraciones UX:
+    validations:
+      required: false
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: "Dependencias"
+      placeholder: |
+        - Bloqueada por: #
+        - Requiere: #
+        - Decisiones pendientes:
+    validations:
+      required: false


### PR DESCRIPTION
## Descripción
Se agregan **Issue Forms (YAML)** para estandarizar la creación de trabajo en GitHub y hacer el proceso auditable, alineado al DoR del proyecto.

## Cambios
- Se agregan plantillas en `.github/ISSUE_TEMPLATE/`:
  - `user-story.yml` (Historias de usuario)
  - `bug.yml` (Bugs)
  - `tech-debt.yml` (Deuda técnica / refactor)
  - `config.yml` (configuración de templates)